### PR TITLE
specify file encoding

### DIFF
--- a/010_forecast/20190714_R言語における日本の祝日判定/jholiday.R
+++ b/010_forecast/20190714_R言語における日本の祝日判定/jholiday.R
@@ -23,7 +23,7 @@ is.jholiday <- function(target_date,
   target_date <- as.Date(target_date)
   
   # holiday_sourceをもとに祝日を取得
-  holidays <- read.csv(holiday_source)
+  holidays <- read.csv(holiday_source, fileEncoding = "CP932")
   colnames(holidays) <- c("date", "holyday_name")
   holidays$date <- as.Date(holidays$date)
 


### PR DESCRIPTION
便利な関数を提供していただきありがとうございます。
参照しているCSVファイルの文字コードがShift-JISであるため、
Windows以外の環境でも動作するように、read.csv()に文字コード指定（CP932）を追加しました。